### PR TITLE
add resources for cloudTrail, elasticsearch, elastiCache, glue, guardDuty, inspector, lakeFormation

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -115,6 +115,7 @@ func getRealState(session *session.Session) (resources resourceMap) {
 		getGlue(session),
 		getGuardDuty(session),
 		getIam(session),
+		getInspector(session),
 		getKinesis(session),
 		getKinesisAnalytics(session),
 		getKinesisAnalyticsV2(session),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -113,6 +113,7 @@ func getRealState(session *session.Session) (resources resourceMap) {
 		getFirehose(session),
 		getFsx(session),
 		getGlue(session),
+		getGuardDuty(session),
 		getIam(session),
 		getKinesis(session),
 		getKinesisAnalytics(session),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -107,6 +107,7 @@ func getRealState(session *session.Session) (resources resourceMap) {
 		getEcs(session),
 		getEfs(session),
 		getEks(session),
+		getElasticache(session),
 		getElasticsearch(session),
 		getElasticLoadBalancingV2(session),
 		getFirehose(session),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -97,6 +97,7 @@ func getRealState(session *session.Session) (resources resourceMap) {
 		getAutoScalingPlans(session),
 		getBackup(session),
 		getCloudfront(session),
+		getCloudTrail(session),
 		getCloudWatch(session),
 		getCloudWatchEvents(session),
 		getConfig(session),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -112,6 +112,7 @@ func getRealState(session *session.Session) (resources resourceMap) {
 		getElasticLoadBalancingV2(session),
 		getFirehose(session),
 		getFsx(session),
+		getGlue(session),
 		getIam(session),
 		getKinesis(session),
 		getKinesisAnalytics(session),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -120,6 +120,7 @@ func getRealState(session *session.Session) (resources resourceMap) {
 		getKinesisAnalytics(session),
 		getKinesisAnalyticsV2(session),
 		getKms(session),
+		getLakeFormation(session),
 		getLambda(session),
 		getCloudwatchLogs(session),
 		getMsk(session),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -107,6 +107,7 @@ func getRealState(session *session.Session) (resources resourceMap) {
 		getEcs(session),
 		getEfs(session),
 		getEks(session),
+		getElasticsearch(session),
 		getElasticLoadBalancingV2(session),
 		getFirehose(session),
 		getFsx(session),

--- a/aws/resources_cloudtrail.go
+++ b/aws/resources_cloudtrail.go
@@ -1,0 +1,27 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudtrail"
+)
+
+func getCloudTrail(session *session.Session) (resources resourceMap) {
+	client := cloudtrail.New(session)
+	resourcesSliceErrorMap := resourceSliceErrorMap{
+		cloudTrailTrail: getCloudTrailTrail(client),
+	}
+	resources = resourcesSliceErrorMap.unwrap()
+	return
+}
+
+func getCloudTrailTrail(client *cloudtrail.CloudTrail) (r resourceSliceError) {
+	r.err = client.ListTrailsPages(&cloudtrail.ListTrailsInput{}, func(page *cloudtrail.ListTrailsOutput, lastPage bool) bool {
+		logDebug("List CloudTrailTrail resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.Trails {
+			logDebug("Got CloudTrailTrail resource with PhysicalResourceId", *resource.Name)
+			r.resources = append(r.resources, *resource.Name)
+		}
+		return true
+	})
+	return
+}

--- a/aws/resources_elasticache.go
+++ b/aws/resources_elasticache.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+)
+
+func getElasticache(session *session.Session) (resources resourceMap) {
+	client := elasticache.New(session)
+	resourcesSliceErrorMap := resourceSliceErrorMap{
+		elastiCacheCacheCluster:     getElastiCacheCacheCluster(client),
+		elastiCacheParameterGroup:   getElastiCacheParameterGroup(client),
+		elastiCacheReplicationGroup: getElastiCacheReplicationGroup(client),
+		elastiCacheSecurityGroup:    getElastiCacheSecurityGroup(client),
+		elastiCacheSubnetGroup:      getElastiCacheSubnetGroup(client),
+	}
+	resources = resourcesSliceErrorMap.unwrap()
+	return
+}
+
+func getElastiCacheCacheCluster(client *elasticache.ElastiCache) (r resourceSliceError) {
+	r.err = client.DescribeCacheClustersPages(&elasticache.DescribeCacheClustersInput{}, func(page *elasticache.DescribeCacheClustersOutput, lastPage bool) bool {
+		logDebug("Listing ElastiCacheCacheCluster resources page. Remaining pages", page.Marker)
+		for _, resource := range page.CacheClusters {
+			logDebug("Got ElastiCacheCacheCluster resource with PhysicalResourceId", *resource.CacheClusterId)
+			r.resources = append(r.resources, *resource.CacheClusterId)
+		}
+		return true
+	})
+	return
+}
+
+func getElastiCacheParameterGroup(client *elasticache.ElastiCache) (r resourceSliceError) {
+	r.err = client.DescribeCacheParameterGroupsPages(&elasticache.DescribeCacheParameterGroupsInput{}, func(page *elasticache.DescribeCacheParameterGroupsOutput, lastPage bool) bool {
+		logDebug("Listing ElastiCacheParameterGroup resources page. Remaining pages", page.Marker)
+		for _, resource := range page.CacheParameterGroups {
+			logDebug("Got ElastiCacheParameterGroup resource with PhysicalResourceId", *resource.CacheParameterGroupName)
+			r.resources = append(r.resources, *resource.CacheParameterGroupName)
+		}
+		return true
+	})
+	return
+}
+
+func getElastiCacheReplicationGroup(client *elasticache.ElastiCache) (r resourceSliceError) {
+	r.err = client.DescribeReplicationGroupsPages(&elasticache.DescribeReplicationGroupsInput{}, func(page *elasticache.DescribeReplicationGroupsOutput, lastPage bool) bool {
+		logDebug("Listing ElastiCacheReplicationGroup resources page. Remaining pages", page.Marker)
+		for _, resource := range page.ReplicationGroups {
+			logDebug("Got ElastiCacheReplicationGroup resource with PhysicalResourceId", *resource.ReplicationGroupId)
+			r.resources = append(r.resources, *resource.ReplicationGroupId)
+		}
+		return true
+	})
+	return
+}
+
+func getElastiCacheSecurityGroup(client *elasticache.ElastiCache) (r resourceSliceError) {
+	r.err = client.DescribeCacheSecurityGroupsPages(&elasticache.DescribeCacheSecurityGroupsInput{}, func(page *elasticache.DescribeCacheSecurityGroupsOutput, lastPage bool) bool {
+		logDebug("Listing ElastiCacheSecurityGroup resources page. Remaining pages", page.Marker)
+		for _, resource := range page.CacheSecurityGroups {
+			logDebug("Got ElastiCacheSecurityGroup resource with PhysicalResourceId", *resource.CacheSecurityGroupName)
+			r.resources = append(r.resources, *resource.CacheSecurityGroupName)
+		}
+		return true
+	})
+	return
+}
+
+func getElastiCacheSubnetGroup(client *elasticache.ElastiCache) (r resourceSliceError) {
+	r.err = client.DescribeCacheSubnetGroupsPages(&elasticache.DescribeCacheSubnetGroupsInput{}, func(page *elasticache.DescribeCacheSubnetGroupsOutput, lastPage bool) bool {
+		logDebug("Listing ElastiCacheSubnetGroup resources page. Remaining pages", page.Marker)
+		for _, resource := range page.CacheSubnetGroups {
+			logDebug("Got ElastiCacheSubnetGroup resource with PhysicalResourceId", *resource.CacheSubnetGroupName)
+			r.resources = append(r.resources, *resource.CacheSubnetGroupName)
+		}
+		return true
+	})
+	return
+}

--- a/aws/resources_elasticsearch.go
+++ b/aws/resources_elasticsearch.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elasticsearchservice"
+)
+
+func getElasticsearch(session *session.Session) (resources resourceMap) {
+	client := elasticsearchservice.New(session)
+	resourcesSliceErrorMap := resourceSliceErrorMap{
+		elasticsearchDomain: getElasticsearchDomain(client),
+	}
+	resources = resourcesSliceErrorMap.unwrap()
+	return
+}
+
+func getElasticsearchDomain(client *elasticsearchservice.ElasticsearchService) (r resourceSliceError) {
+	page, err := client.ListDomainNames(&elasticsearchservice.ListDomainNamesInput{})
+	if err != nil {
+		r.err = err
+		return
+	}
+	logDebug("Listing ElasticsearchDomain resources page.")
+	for _, resource := range page.DomainNames {
+		logDebug("Got ElasticsearchDomain resource with PhysicalResourceId", *resource.DomainName)
+		r.resources = append(r.resources, *resource.DomainName)
+	}
+	return
+}

--- a/aws/resources_glue.go
+++ b/aws/resources_glue.go
@@ -1,0 +1,144 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/glue"
+)
+
+func getGlue(session *session.Session) (resources resourceMap) {
+	client := glue.New(session)
+	resourcesSliceErrorMap := resourceSliceErrorMap{
+		glueConnection:            getGlueConnection(client),
+		glueCrawler:               getGlueCrawler(client),
+		glueDatabase:              getGlueDatabase(client),
+		glueDevEndpoint:           getGlueDevEndpoint(client),
+		glueJob:                   getGlueJob(client),
+		glueMLTransform:           getGlueMLTransform(client),
+		glueSecurityConfiguration: getGlueSecurityConfiguration(client),
+		glueTable:                 getGlueTable(client),
+		glueTrigger:               getGlueTrigger(client),
+		glueWorkflow:              getGlueWorkflow(client),
+	}
+	resources = resourcesSliceErrorMap.unwrap()
+	return
+}
+
+func getGlueConnection(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.GetConnectionsPages(&glue.GetConnectionsInput{}, func(page *glue.GetConnectionsOutput, lastPage bool) bool {
+		logDebug("Listing GlueConnection resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.ConnectionList {
+			logDebug("Got GlueConnection resource with PhysicalResourceId", *resource.Name)
+			r.resources = append(r.resources, *resource.Name)
+		}
+		return true
+	})
+	return
+}
+
+func getGlueCrawler(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.GetCrawlersPages(&glue.GetCrawlersInput{}, func(page *glue.GetCrawlersOutput, lastPage bool) bool {
+		logDebug("Listing GlueCrawler resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.Crawlers {
+			logDebug("Got GlueCrawler resource with PhysicalResourceId", *resource.Name)
+			r.resources = append(r.resources, *resource.Name)
+		}
+		return true
+	})
+	return
+}
+
+func getGlueDatabase(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.GetDatabasesPages(&glue.GetDatabasesInput{}, func(page *glue.GetDatabasesOutput, lastPage bool) bool {
+		logDebug("Listing GlueDatabase resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.DatabaseList {
+			logDebug("Got GlueDatabase resource with PhysicalResourceId", *resource.Name)
+			r.resources = append(r.resources, *resource.Name)
+		}
+		return true
+	})
+	return
+}
+
+func getGlueDevEndpoint(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.GetDevEndpointsPages(&glue.GetDevEndpointsInput{}, func(page *glue.GetDevEndpointsOutput, lastPage bool) bool {
+		logDebug("Listing GlueDevEndpoint resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.DevEndpoints {
+			logDebug("Got GlueDevEndpoint resource with PhysicalResourceId", *resource.EndpointName)
+			r.resources = append(r.resources, *resource.EndpointName)
+		}
+		return true
+	})
+	return
+}
+
+func getGlueJob(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.GetJobsPages(&glue.GetJobsInput{}, func(page *glue.GetJobsOutput, lastPage bool) bool {
+		logDebug("Listing GlueJob resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.Jobs {
+			logDebug("Got GlueJob resource with PhysicalResourceId", *resource.Name)
+			r.resources = append(r.resources, *resource.Name)
+		}
+		return true
+	})
+	return
+}
+
+func getGlueMLTransform(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.GetMLTransformsPages(&glue.GetMLTransformsInput{}, func(page *glue.GetMLTransformsOutput, lastPage bool) bool {
+		logDebug("Listing GlueMLTransform resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.Transforms {
+			logDebug("Got GlueMLTransform resource with PhysicalResourceId", *resource.Name)
+			r.resources = append(r.resources, *resource.Name)
+		}
+		return true
+	})
+	return
+}
+
+func getGlueSecurityConfiguration(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.GetSecurityConfigurationsPages(&glue.GetSecurityConfigurationsInput{}, func(page *glue.GetSecurityConfigurationsOutput, lastPage bool) bool {
+		logDebug("Listing GlueSecurityConfiguration resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.SecurityConfigurations {
+			logDebug("Got GlueSecurityConfiguration resource with PhysicalResourceId", *resource.Name)
+			r.resources = append(r.resources, *resource.Name)
+		}
+		return true
+	})
+	return
+}
+
+func getGlueTable(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.GetTablesPages(&glue.GetTablesInput{}, func(page *glue.GetTablesOutput, lastPage bool) bool {
+		logDebug("Listing GlueTable resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.TableList {
+			logDebug("Got GlueTable resource with PhysicalResourceId", *resource.Name)
+			r.resources = append(r.resources, *resource.Name)
+		}
+		return true
+	})
+	return
+}
+
+func getGlueTrigger(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.GetTriggersPages(&glue.GetTriggersInput{}, func(page *glue.GetTriggersOutput, lastPage bool) bool {
+		logDebug("Listing GlueTrigger resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.Triggers {
+			logDebug("Got GlueTrigger resource with PhysicalResourceId", *resource.Name)
+			r.resources = append(r.resources, *resource.Name)
+		}
+		return true
+	})
+	return
+}
+
+func getGlueWorkflow(client *glue.Glue) (r resourceSliceError) {
+	r.err = client.ListWorkflowsPages(&glue.ListWorkflowsInput{}, func(page *glue.ListWorkflowsOutput, lastPage bool) bool {
+		logDebug("Listing GlueWorkflow resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.Workflows {
+			logDebug("Got GlueWorkflow resource with PhysicalResourceId", *resource)
+			r.resources = append(r.resources, *resource)
+		}
+		return true
+	})
+	return
+}

--- a/aws/resources_guardduty.go
+++ b/aws/resources_guardduty.go
@@ -1,0 +1,27 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+)
+
+func getGuardDuty(session *session.Session) (resources resourceMap) {
+	client := guardduty.New(session)
+	resourcesSliceErrorMap := resourceSliceErrorMap{
+		guardDutyDetector: getGuardDutyDetector(client),
+	}
+	resources = resourcesSliceErrorMap.unwrap()
+	return
+}
+
+func getGuardDutyDetector(client *guardduty.GuardDuty) (r resourceSliceError) {
+	r.err = client.ListDetectorsPages(&guardduty.ListDetectorsInput{}, func(page *guardduty.ListDetectorsOutput, lastPage bool) bool {
+		logDebug("Listing GuardDutyDetector resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.DetectorIds {
+			logDebug("Got GuardDutyDetector resource with PhysicalResourceId", *resource)
+			r.resources = append(r.resources, *resource)
+		}
+		return true
+	})
+	return
+}

--- a/aws/resources_inspector.go
+++ b/aws/resources_inspector.go
@@ -1,0 +1,40 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/inspector"
+)
+
+func getInspector(session *session.Session) (resources resourceMap) {
+	client := inspector.New(session)
+	resourcesSliceErrorMap := resourceSliceErrorMap{
+		inspectorAssessmentTarget:   getInspectorAssessmentTarget(client),
+		inspectorAssessmentTemplate: getInspectorAssessmentTemplate(client),
+	}
+	resources = resourcesSliceErrorMap.unwrap()
+	return
+}
+
+func getInspectorAssessmentTarget(client *inspector.Inspector) (r resourceSliceError) {
+	r.err = client.ListAssessmentTargetsPages(&inspector.ListAssessmentTargetsInput{}, func(page *inspector.ListAssessmentTargetsOutput, lastPage bool) bool {
+		logDebug("Listing InspectorAssessmentTarget resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.AssessmentTargetArns {
+			logDebug("Got InspectorAssessmentTarget resource with PhysicalResourceId", *resource)
+			r.resources = append(r.resources, *resource)
+		}
+		return true
+	})
+	return
+}
+
+func getInspectorAssessmentTemplate(client *inspector.Inspector) (r resourceSliceError) {
+	r.err = client.ListAssessmentTemplatesPages(&inspector.ListAssessmentTemplatesInput{}, func(page *inspector.ListAssessmentTemplatesOutput, lastPage bool) bool {
+		logDebug("Listing InspectorAssessmentTemplate resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.AssessmentTemplateArns {
+			logDebug("Got InspectorAssessmentTemplate resource with PhysicalResourceId", *resource)
+			r.resources = append(r.resources, *resource)
+		}
+		return true
+	})
+	return
+}

--- a/aws/resources_lakeformation.go
+++ b/aws/resources_lakeformation.go
@@ -1,0 +1,27 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/lakeformation"
+)
+
+func getLakeFormation(session *session.Session) (resources resourceMap) {
+	client := lakeformation.New(session)
+	resourcesSliceErrorMap := resourceSliceErrorMap{
+		lakeFormationResource: getLakeFormationResource(client),
+	}
+	resources = resourcesSliceErrorMap.unwrap()
+	return
+}
+
+func getLakeFormationResource(client *lakeformation.LakeFormation) (r resourceSliceError) {
+	r.err = client.ListResourcesPages(&lakeformation.ListResourcesInput{}, func(page *lakeformation.ListResourcesOutput, lastPage bool) bool {
+		logDebug("Listing LakeFormationResource resources page. Remaining pages", page.NextToken)
+		for _, resource := range page.ResourceInfoList {
+			logDebug("Got LakeFormationResource resource with PhysicalResourceId", *resource.ResourceArn)
+			r.resources = append(r.resources, *resource.ResourceArn)
+		}
+		return true
+	})
+	return
+}

--- a/aws/state.go
+++ b/aws/state.go
@@ -306,15 +306,12 @@ const (
 	gameLiftMatchmakingConfiguration           resourceType = "gameLiftMatchmakingConfiguration"
 	gameLiftMatchmakingRuleSet                 resourceType = "gameLiftMatchmakingRuleSet"
 	gameLiftScript                             resourceType = "gameLiftScript"
-	glueClassifier                             resourceType = "glueClassifier"
 	glueConnection                             resourceType = "glueConnection"
 	glueCrawler                                resourceType = "glueCrawler"
 	glueDatabase                               resourceType = "glueDatabase"
-	glueDataCatalogEncryptionSettings          resourceType = "glueDataCatalogEncryptionSettings"
 	glueDevEndpoint                            resourceType = "glueDevEndpoint"
 	glueJob                                    resourceType = "glueJob"
 	glueMLTransform                            resourceType = "glueMLTransform"
-	gluePartition                              resourceType = "gluePartition"
 	glueSecurityConfiguration                  resourceType = "glueSecurityConfiguration"
 	glueTable                                  resourceType = "glueTable"
 	glueTrigger                                resourceType = "glueTrigger"
@@ -711,15 +708,12 @@ func fromCloudFormationType(cloudFormationType string) (resourceType, bool) {
 		"AWS::GameLift::MatchmakingConfiguration":           gameLiftMatchmakingConfiguration,
 		"AWS::GameLift::MatchmakingRuleSet":                 gameLiftMatchmakingRuleSet,
 		"AWS::GameLift::Script":                             gameLiftScript,
-		"AWS::Glue::Classifier":                             glueClassifier,
 		"AWS::Glue::Connection":                             glueConnection,
 		"AWS::Glue::Crawler":                                glueCrawler,
 		"AWS::Glue::Database":                               glueDatabase,
-		"AWS::Glue::DataCatalogEncryptionSettings":          glueDataCatalogEncryptionSettings,
 		"AWS::Glue::DevEndpoint":                            glueDevEndpoint,
 		"AWS::Glue::Job":                                    glueJob,
 		"AWS::Glue::MLTransform":                            glueMLTransform,
-		"AWS::Glue::Partition":                              gluePartition,
 		"AWS::Glue::SecurityConfiguration":                  glueSecurityConfiguration,
 		"AWS::Glue::Table":                                  glueTable,
 		"AWS::Glue::Trigger":                                glueTrigger,

--- a/aws/state.go
+++ b/aws/state.go
@@ -366,8 +366,6 @@ const (
 	kinesisFirehoseDeliveryStream              resourceType = "kinesisFirehoseDeliveryStream"
 	kmsAlias                                   resourceType = "kmsAlias"
 	kmsKey                                     resourceType = "kmsKey"
-	lakeFormationDataLakeSettings              resourceType = "lakeFormationDataLakeSettings"
-	lakeFormationPermissions                   resourceType = "lakeFormationPermissions"
 	lakeFormationResource                      resourceType = "lakeFormationResource"
 	lambdaAlias                                resourceType = "lambdaAlias"
 	lambdaFunction                             resourceType = "lambdaFunction"
@@ -762,8 +760,6 @@ func fromCloudFormationType(cloudFormationType string) (resourceType, bool) {
 		"AWS::KinesisFirehose::DeliveryStream":              kinesisFirehoseDeliveryStream,
 		"AWS::KMS::Alias":                                   kmsAlias,
 		"AWS::KMS::Key":                                     kmsKey,
-		"AWS::LakeFormation::DataLakeSettings":              lakeFormationDataLakeSettings,
-		"AWS::LakeFormation::Permissions":                   lakeFormationPermissions,
 		"AWS::LakeFormation::Resource":                      lakeFormationResource,
 		"AWS::Lambda::Alias":                                lambdaAlias,
 		"AWS::Lambda::Function":                             lambdaFunction,

--- a/aws/state.go
+++ b/aws/state.go
@@ -317,11 +317,6 @@ const (
 	glueTrigger                                resourceType = "glueTrigger"
 	glueWorkflow                               resourceType = "glueWorkflow"
 	guardDutyDetector                          resourceType = "guardDutyDetector"
-	guardDutyFilter                            resourceType = "guardDutyFilter"
-	guardDutyIPSet                             resourceType = "guardDutyIPSet"
-	guardDutyMaster                            resourceType = "guardDutyMaster"
-	guardDutyMember                            resourceType = "guardDutyMember"
-	guardDutyThreatIntelSet                    resourceType = "guardDutyThreatIntelSet"
 	iamAccessKey                               resourceType = "iamAccessKey"
 	iamGroup                                   resourceType = "iamGroup"
 	iamInstanceProfile                         resourceType = "iamInstanceProfile"
@@ -719,11 +714,6 @@ func fromCloudFormationType(cloudFormationType string) (resourceType, bool) {
 		"AWS::Glue::Trigger":                                glueTrigger,
 		"AWS::Glue::Workflow":                               glueWorkflow,
 		"AWS::GuardDuty::Detector":                          guardDutyDetector,
-		"AWS::GuardDuty::Filter":                            guardDutyFilter,
-		"AWS::GuardDuty::IPSet":                             guardDutyIPSet,
-		"AWS::GuardDuty::Master":                            guardDutyMaster,
-		"AWS::GuardDuty::Member":                            guardDutyMember,
-		"AWS::GuardDuty::ThreatIntelSet":                    guardDutyThreatIntelSet,
 		"AWS::IAM::AccessKey":                               iamAccessKey,
 		"AWS::IAM::Group":                                   iamGroup,
 		"AWS::IAM::InstanceProfile":                         iamInstanceProfile,

--- a/aws/state.go
+++ b/aws/state.go
@@ -278,7 +278,6 @@ const (
 	elastiCacheParameterGroup                  resourceType = "elastiCacheParameterGroup"
 	elastiCacheReplicationGroup                resourceType = "elastiCacheReplicationGroup"
 	elastiCacheSecurityGroup                   resourceType = "elastiCacheSecurityGroup"
-	elastiCacheSecurityGroupIngress            resourceType = "elastiCacheSecurityGroupIngress"
 	elastiCacheSubnetGroup                     resourceType = "elastiCacheSubnetGroup"
 	elasticsearchDomain                        resourceType = "elasticsearchDomain"
 	elasticBeanstalkApplication                resourceType = "elasticBeanstalkApplication"
@@ -684,7 +683,6 @@ func fromCloudFormationType(cloudFormationType string) (resourceType, bool) {
 		"AWS::ElastiCache::ParameterGroup":                  elastiCacheParameterGroup,
 		"AWS::ElastiCache::ReplicationGroup":                elastiCacheReplicationGroup,
 		"AWS::ElastiCache::SecurityGroup":                   elastiCacheSecurityGroup,
-		"AWS::ElastiCache::SecurityGroupIngress":            elastiCacheSecurityGroupIngress,
 		"AWS::ElastiCache::SubnetGroup":                     elastiCacheSubnetGroup,
 		"AWS::Elasticsearch::Domain":                        elasticsearchDomain,
 		"AWS::ElasticBeanstalk::Application":                elasticBeanstalkApplication,

--- a/aws/state.go
+++ b/aws/state.go
@@ -327,7 +327,6 @@ const (
 	iamUser                                    resourceType = "iamUser"
 	inspectorAssessmentTarget                  resourceType = "inspectorAssessmentTarget"
 	inspectorAssessmentTemplate                resourceType = "inspectorAssessmentTemplate"
-	inspectorResourceGroup                     resourceType = "inspectorResourceGroup"
 	ioTCertificate                             resourceType = "ioTCertificate"
 	ioTPolicy                                  resourceType = "ioTPolicy"
 	ioTPolicyPrincipalAttachment               resourceType = "ioTPolicyPrincipalAttachment"
@@ -724,7 +723,6 @@ func fromCloudFormationType(cloudFormationType string) (resourceType, bool) {
 		"AWS::IAM::User":                                    iamUser,
 		"AWS::Inspector::AssessmentTarget":                  inspectorAssessmentTarget,
 		"AWS::Inspector::AssessmentTemplate":                inspectorAssessmentTemplate,
-		"AWS::Inspector::ResourceGroup":                     inspectorResourceGroup,
 		"AWS::IoT::Certificate":                             ioTCertificate,
 		"AWS::IoT::Policy":                                  ioTPolicy,
 		"AWS::IoT::PolicyPrincipalAttachment":               ioTPolicyPrincipalAttachment,


### PR DESCRIPTION
Relates #1 

Added:
- cloudTrailTrail
- elasticsearchDomain
- elastiCacheCacheCluster
- elastiCacheParameterGroup
- elastiCacheReplicationGroup
- elastiCacheSecurityGroup
- elastiCacheSubnetGroup
- glueConnection
- glueCrawler
- glueDatabase
- glueDevEndpoint
- glueJob
- glueMLTransform
- glueSecurityConfiguration
- glueTable
- glueTrigger
- glueWorkflow
- guardDutyDetector
- inspectorAssessmentTarget
- inspectorAssessmentTemplate
- lakeFormationResource

Removed from state:
- elastiCacheSecurityGroupIngress
- glueClassifier
- glueDataCatalogEncryptionSettings
- gluePartition
- guardDutyFilter
- guardDutyIPSet
- guardDutyMaster
- guardDutyMember
- guardDutyThreatIntelSet
- inspectorResourceGroup
- lakeFormationDataLakeSettings
- lakeFormationPermissions